### PR TITLE
fix(safari): callback-based syntax,  use create buffer source, AudioContext requires resume

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@
   window.addEventListener("load", () => {
     const button = document.body.querySelector("#buttonStart");
     button.addEventListener("click", () => {
+      // safari AudioContext requires resume
+      context.resume();
       fetch("7sxtEOR7zhrd-60sec-fade-out.128.mp3")
         .then(response => {
           return response.arrayBuffer();

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@
     node.addEventListener("ended", () => {
       node.stop();
       node.disconnect();
+      node.buffer = null;
       node = null;
     });
     node.start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 (() => {
-  const AudioContext = window.AudioContext || (window as any).webkitAudioContext;
+  const AudioContext =
+    window.AudioContext || (window as any).webkitAudioContext;
   let context = new AudioContext();
   let source: AudioBuffer = null;
   window.addEventListener("load", () => {
@@ -10,7 +11,20 @@
           return response.arrayBuffer();
         })
         .then(buffer => {
-          return context.decodeAudioData(buffer);
+          // safari does not support promise-based syntax
+          // BaseAudioContext.decodeAudioData()
+          // https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/decodeAudioData
+          return new Promise<AudioBuffer>((resolve, reject) => {
+            context.decodeAudioData(
+              buffer,
+              (buf: AudioBuffer) => {
+                resolve(buf);
+              },
+              (error: DOMException) => {
+                reject(error);
+              }
+            );
+          });
         })
         .then(decodeAudio => {
           source = decodeAudio;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,10 @@
   });
 
   function play() {
-    let node = new AudioBufferSourceNode(context, { buffer: source });
+    // safari does not have AudioBufferSourceNode() constructor
+    // https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/AudioBufferSourceNode
+    let node = context.createBufferSource();
+    node.buffer = source;
     node.connect(context.destination);
     node.addEventListener("ended", () => {
       node.stop();


### PR DESCRIPTION
safari does not support promise-based syntax
BaseAudioContext.decodeAudioData()
https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/decodeAudioData

fixes #16

Use create buffer source

AudioContext requires resume